### PR TITLE
Handle SIGCHLD to reap workers

### DIFF
--- a/.travis_build_config.rb
+++ b/.travis_build_config.rb
@@ -6,8 +6,9 @@ MRuby::Build.new do |conf|
 
   conf.gem core: 'mruby-io' if ENV['EXAMPLE']
 
+  conf.enable_debug
+  conf.gem mgem: 'mruby-errno'
   if ENV['DEBUG'] == 'true'
-    conf.enable_debug
     conf.cc.defines = %w(MRB_ENABLE_DEBUG_HOOK)
     conf.gem core: 'mruby-bin-debugger'
   end

--- a/example/fd_watch.rb
+++ b/example/fd_watch.rb
@@ -8,10 +8,13 @@ pid = fork do
     puts "[#{Process.pid}] wait..."
     sleep 1
   end
-  w.write 'a'
-  loop do
+  data = 'mruby!'.split('')
+  while c = data.shift
     sleep 1
+    puts "Sending #{c.inspect}"
+    w.write c
   end
+  w.close
 end
 w.close
 loop.pid = pid
@@ -19,9 +22,12 @@ loop.register_timer(FiberedWorker::SIGRTMIN, 1000, 1000) do |signo|
   puts "[#{Process.pid}] wait..."
 end
 
-loop.register_fd(r.fileno) do |data|
-  puts "received: #{data}"
-  Process.kill :TERM, pid
+loop.register_fd(r.fileno, false) do |data|
+  puts "received: #{data}(#{data.chr.inspect})"
+  if data == '!'.ord
+    puts "Then finish"
+    Process.kill :TERM, pid
+  end
 end
 
 puts "Parent: [#{Process.pid}]"

--- a/example/fd_watch.rb
+++ b/example/fd_watch.rb
@@ -1,4 +1,4 @@
-loop = FiberedWorker::MainLoop.new
+loop = FiberedWorker::MainLoop.new(interval: 0)
 r, w = IO.pipe
 
 pid = fork do

--- a/example/legacy_cpu_util.rb
+++ b/example/legacy_cpu_util.rb
@@ -1,0 +1,28 @@
+loop = FiberedWorker::MainLoop.new
+mode = ARGV[0]
+if mode == 'legacy'
+  loop.use_legacy_watchdog = true
+  loop.interval = ARGV[1] ? ARGV[1].to_i : 0
+end
+puts "Mode: #{mode == 'legacy' ? mode : 'sigchld'}"
+
+pid = fork do
+  puts "[#{Process.pid}] This is child"
+  loop do
+    sleep 1
+    # puts "[#{Process.pid}] Child is looping"
+  end
+end
+
+loop.pid = pid
+loop.register_timer(FiberedWorker::SIGRTMIN, 500, 500) do |signo|
+  puts "current CPU usage:"
+  system "ps auf | grep -e CPU -e mruby | grep -v grep"
+end
+
+loop.register_timer(FiberedWorker::SIGRTMIN+1, 3000) do |signo|
+  puts "Then exit..."
+  Process.kill :TERM, pid
+end
+
+puts "Loop exited: #{loop.run.inspect}"

--- a/example/multi_timer.rb
+++ b/example/multi_timer.rb
@@ -12,15 +12,20 @@ l.register_handler(SIGRT4) do
   puts "Killing #{pid1}"
   ::Process.kill FiberedWorker::SIGTERM, pid1
 end
-l.register_handler(SIGRT5) do
-  puts "Killing #{pid2}"
-  ::Process.kill FiberedWorker::SIGTERM, pid2
+cnt = 0
+l.register_handler(SIGRT5, false) do
+  cnt += 1
+  puts "Got SIGRT5 in #{cnt} time(s)"
+  if cnt >= 5
+    puts "Then killing #{pid2}"
+    ::Process.kill FiberedWorker::SIGTERM, pid2
+  end
 end
 
 t = FiberedWorker::Timer.new(SIGRT4)
 t.start 200
 t2 = FiberedWorker::Timer.new(SIGRT5)
-t2.start 300
+t2.start 300, 300
 
 p "pids: #{l.pids}"
 ret = l.run

--- a/src/mrb_fiberedworker.c
+++ b/src/mrb_fiberedworker.c
@@ -175,10 +175,13 @@ static mrb_value mrb_fw_read_nonblock(mrb_state *mrb, mrb_value self)
 {
   int ret;
   mrb_int fd;
-  uint64_t result;
+  uint64_t result = 0;
   mrb_get_args(mrb, "i", &fd);
-  ret = read(fd, &result, sizeof(result));
-  if (ret == -1) {
+  ret = read((int)fd, &result, sizeof(result));
+  if(!ret) {
+    /* no content is read */
+    return mrb_nil_value();
+  } else if (ret == -1) {
     if (errno == EAGAIN) {
       return mrb_nil_value();
     } else {


### PR DESCRIPTION
This allows supervisors to make busy-loop wait and on that case saves CPU!!!

legacy:

```
USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND                                                    
vagrant    625 98.6  0.0  14408  3932 pts/2    S+   08:33   0:02  \_ ./mruby/bin/mruby example/legacy_cpu_util.rb legacy    
vagrant    626  0.0  0.0  14252   940 pts/2    S+   08:33   0:00      \_ ./mruby/bin/mruby example/legacy_cpu_util.rb legacy
```

new:

```
USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND                                                   
vagrant    704  0.3  0.0  14252  3908 pts/2    S+   08:34   0:00  \_ ./mruby/bin/mruby example/legacy_cpu_util.rb          
vagrant    705  0.0  0.0  14252   940 pts/2    S+   08:34   0:00      \_ ./mruby/bin/mruby example/legacy_cpu_util.rb      
```